### PR TITLE
update: signingConfigs 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 
 # Signing files
 .signing/
+/keystores/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,10 +17,32 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        release {
+            Properties keystoreProperties = new Properties()
+            keystoreProperties.load(rootProject.file("./keystores/keystore.properties").newDataInputStream())
+
+            storeFile rootProject.file("./keystores/STORM_keystores.jks")
+
+            keyAlias keystoreProperties['keyAlias']
+            keyPassword keystoreProperties['keyPassword']
+            storePassword keystoreProperties['storePassword']
+        }
+        debug {
+
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+            signingConfig signingConfigs.release
+        }
+
+        debug {
+            signingConfig signingConfigs.release
         }
     }
 }


### PR DESCRIPTION
release key를 통일 시키기 위해 keystore에 담아 자동으로 서명되도록 하였습니다.
디버그 시에도 release key를 사용하여 앞으로 있을 api를 호출 할 때 별도의 키 전환이 필요 없고 릴리즈 시에도 수정이 필요 없습니다.
키 파일은 슬랙을 통해 공유하겠습니다.