### PR TITLE
Feature/refactor recyclerview

### DIFF
--- a/app/src/main/java/com/stormers/storm/MainView/MainActivity.kt
+++ b/app/src/main/java/com/stormers/storm/MainView/MainActivity.kt
@@ -64,11 +64,10 @@ class MainActivity : BaseActivity() {
 
 
         // ParticipatedProjectAdapter
-        participatedProjectsAdapter =
-            ParticipatedProjectsAdapter(this)
+        participatedProjectsAdapter = ParticipatedProjectsAdapter()
         recycler_participated_projects_list.adapter = participatedProjectsAdapter
         recycler_participated_projects_list.layoutManager = LinearLayoutManager(this, RecyclerView.HORIZONTAL, false)
-        recycler_participated_projects_list.addItemDecoration(MarginDecoration(baseContext,16,RecyclerView.HORIZONTAL))
+        recycler_participated_projects_list.addItemDecoration(MarginDecoration(baseContext,16, RecyclerView.HORIZONTAL))
         loadProjectsDatas()
     }
 
@@ -139,8 +138,6 @@ class MainActivity : BaseActivity() {
             )
         }
 
-        participatedProjectsAdapter.datas = datas
-        participatedProjectsAdapter.notifyDataSetChanged()
-
+        participatedProjectsAdapter.addAll(datas)
     }
 }

--- a/app/src/main/java/com/stormers/storm/MainView/ParticipatedProjectsAdapter.kt
+++ b/app/src/main/java/com/stormers/storm/MainView/ParticipatedProjectsAdapter.kt
@@ -5,20 +5,12 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.stormers.storm.R
+import com.stormers.storm.base.BaseAdapter
+import com.stormers.storm.base.BaseViewHolder
 
-class ParticipatedProjectsAdapter (private val context: Context) : RecyclerView.Adapter<ParticipatedProjectsViewHolder>(){
-    var datas = mutableListOf<ParticipatedProjectsData>()
+class ParticipatedProjectsAdapter () : BaseAdapter<ParticipatedProjectsData>(){
 
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ParticipatedProjectsViewHolder {
-        val view = LayoutInflater.from(context).inflate(R.layout.item_participated_projects_list, parent,false)
-        return ParticipatedProjectsViewHolder(view)
-    }
-    override fun getItemCount() : Int{
-        return datas.size
-    }
-
-    override fun onBindViewHolder(holder: ParticipatedProjectsViewHolder, position: Int) {
-        holder.bind(datas[position])
-
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<ParticipatedProjectsData> {
+        return ParticipatedProjectsViewHolder(parent)
     }
 }

--- a/app/src/main/java/com/stormers/storm/MainView/ParticipatedProjectsViewHolder.kt
+++ b/app/src/main/java/com/stormers/storm/MainView/ParticipatedProjectsViewHolder.kt
@@ -1,25 +1,25 @@
 package com.stormers.storm.MainView
 
-import android.view.View
+import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
-import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.stormers.storm.R
+import com.stormers.storm.base.BaseViewHolder
 
-class ParticipatedProjectsViewHolder(itemView:View):RecyclerView.ViewHolder(itemView){
-    val name_of_project = itemView.findViewById<TextView>(R.id.name_of_project)
-    val card1 = itemView.findViewById<ImageView>(R.id.card1)
-    val card2 = itemView.findViewById<ImageView>(R.id.card2)
-    val card3 = itemView.findViewById<ImageView>(R.id.card3)
-    val card4 = itemView.findViewById<ImageView>(R.id.card4)
+class ParticipatedProjectsViewHolder(parent: ViewGroup) : BaseViewHolder<ParticipatedProjectsData>(R.layout.item_participated_projects_list, parent) {
 
-    fun bind(participatedProjectsData: ParticipatedProjectsData){
-        Glide.with(itemView).load(participatedProjectsData.card1).into(card1)
-        Glide.with(itemView).load(participatedProjectsData.card2).into(card2)
-        Glide.with(itemView).load(participatedProjectsData.card3).into(card3)
-        Glide.with(itemView).load(participatedProjectsData.card4).into(card4)
-        name_of_project.text = participatedProjectsData.name_of_project
+    private val nameOfProject = itemView.findViewById<TextView>(R.id.name_of_project)
+    private val card1 = itemView.findViewById<ImageView>(R.id.card1)
+    private val card2 = itemView.findViewById<ImageView>(R.id.card2)
+    private val card3 = itemView.findViewById<ImageView>(R.id.card3)
+    private val card4 = itemView.findViewById<ImageView>(R.id.card4)
 
+    override fun bind(data: ParticipatedProjectsData) {
+        Glide.with(itemView).load(data.card1).into(card1)
+        Glide.with(itemView).load(data.card2).into(card2)
+        Glide.with(itemView).load(data.card3).into(card3)
+        Glide.with(itemView).load(data.card4).into(card4)
+        nameOfProject.text = data.name_of_project
     }
 }

--- a/app/src/main/java/com/stormers/storm/roundmeeting/RoundmeetingFragment.kt
+++ b/app/src/main/java/com/stormers/storm/roundmeeting/RoundmeetingFragment.kt
@@ -29,11 +29,9 @@ class RoundmeetingFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        roundmeetingAdapter = RoundmeetingAdapter(view.context)
+        roundmeetingAdapter = RoundmeetingAdapter()
         RecyclerView_added_card_roundmeeting.adapter = roundmeetingAdapter
         loadRoundmeetingDatas()
-
-
     }
 
     private fun loadRoundmeetingDatas() {
@@ -84,8 +82,7 @@ class RoundmeetingFragment : Fragment() {
             )
         }
 
-        roundmeetingAdapter.datas = datas
-        roundmeetingAdapter.notifyDataSetChanged()
+        roundmeetingAdapter.addAll(datas)
     }
 
 }

--- a/app/src/main/java/com/stormers/storm/roundmeeting/recyclerview/RoundmeetingAdapter.kt
+++ b/app/src/main/java/com/stormers/storm/roundmeeting/recyclerview/RoundmeetingAdapter.kt
@@ -1,25 +1,12 @@
 package com.stormers.storm.roundmeeting.recyclerview
 
-import android.content.Context
-import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.recyclerview.widget.RecyclerView
-import com.stormers.storm.R
-import com.stormers.storm.addcard.recyclerview.AddedCardData
-import com.stormers.storm.addcard.recyclerview.AddedCardViewHolder
+import com.stormers.storm.base.BaseAdapter
+import com.stormers.storm.base.BaseViewHolder
 
-class RoundmeetingAdapter (private val context : Context) : RecyclerView.Adapter<RoundmeetingViewHolder>() {
-    var datas = mutableListOf<RoundmeetingData>()
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RoundmeetingViewHolder {
-        val view = LayoutInflater.from(context).inflate(R.layout.item_roundmeeting, parent, false)
-        return RoundmeetingViewHolder(view)
-    }
+class RoundmeetingAdapter () : BaseAdapter<RoundmeetingData>() {
 
-    override fun getItemCount(): Int {
-        return datas.size
-    }
-
-    override fun onBindViewHolder(holder: RoundmeetingViewHolder, position: Int) {
-        holder.bind(datas[position])
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<RoundmeetingData> {
+        return RoundmeetingViewHolder(parent)
     }
 }

--- a/app/src/main/java/com/stormers/storm/roundmeeting/recyclerview/RoundmeetingViewHolder.kt
+++ b/app/src/main/java/com/stormers/storm/roundmeeting/recyclerview/RoundmeetingViewHolder.kt
@@ -1,18 +1,16 @@
 package com.stormers.storm.roundmeeting.recyclerview
 
-import android.view.View
+import android.view.ViewGroup
 import android.widget.ImageView
-import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.stormers.storm.R
-import com.stormers.storm.addcard.recyclerview.AddedCardData
+import com.stormers.storm.base.BaseViewHolder
 
-class RoundmeetingViewHolder (itemView: View) : RecyclerView.ViewHolder(itemView) {
+class RoundmeetingViewHolder(parent: ViewGroup) : BaseViewHolder<RoundmeetingData>(R.layout.item_roundmeeting, parent) {
     val ImageView_added_card_roundmeeting = itemView.findViewById<ImageView>(R.id.ImageView_added_card_roundmeeting)
 
-
-    fun bind(RoundmeetingData : RoundmeetingData){
-        Glide.with(itemView).load(RoundmeetingData.ImageView_added_card_roundmeeting).into(ImageView_added_card_roundmeeting)
+    override fun bind(data : RoundmeetingData){
+        Glide.with(itemView).load(data.ImageView_added_card_roundmeeting).into(ImageView_added_card_roundmeeting)
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -141,20 +141,26 @@
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recycler_participated_projects_list"
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:paddingHorizontal="26dp"
+            android:clipToPadding="false"
             android:orientation="horizontal"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            tools:listitem="@layout/item_participated_projects_list"
-            android:scrollbars="horizontal"
+
             android:scrollbarAlwaysDrawHorizontalTrack="true"
+            android:scrollbarFadeDuration="0"
+            android:scrollbarStyle="insideInset"
             android:scrollbarThumbHorizontal="@color/storm_yellow"
             android:scrollbarTrackHorizontal="@drawable/mainview_processingbar_1"
-            android:scrollbarFadeDuration="0"
-            android:scrollbarStyle="outsideInset"
-            app:layout_constraintStart_toStartOf="@id/imagebutton_start_storming"
+            android:scrollbars="horizontal"
+
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/textview_past_project_list"
-            app:layout_constraintEnd_toEndOf="parent"/>
+            tools:listitem="@layout/item_participated_projects_list" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
 

--- a/app/src/main/res/layout/fragment_roundmeeting.xml
+++ b/app/src/main/res/layout/fragment_roundmeeting.xml
@@ -19,6 +19,7 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:spanCount="2"
             tools:listitem="@layout/item_roundmeeting" />
 

--- a/app/src/main/res/layout/item_participated_projects_list.xml
+++ b/app/src/main/res/layout/item_participated_projects_list.xml
@@ -70,12 +70,14 @@
         android:fontFamily="@font/notosans_medium"
         android:text="평화의 프로젝트"
         android:textSize="11sp"
+        android:layout_marginVertical="16dp"
         android:textColor="@color/brownish_grey"
         android:includeFontPadding="false"
         app:layout_constraintEnd_toEndOf="@+id/cardview_project_forder"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="@+id/cardview_project_forder"
-        app:layout_constraintTop_toBottomOf="@+id/cardview_project_forder" />
+        app:layout_constraintTop_toBottomOf="@+id/cardview_project_forder"
+        app:layout_constraintBottom_toBottomOf="parent"/>
 
 
 


### PR DESCRIPTION
## BaseAdapter, BaseViewHolder사용
중복코드 해결, 리사이클러뷰 구현에 대한 통일성 부여

### 예제 코드

#### Adapter
```
class ParticipatedProjectsAdapter () : BaseAdapter<ParticipatedProjectsData>(){

    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): BaseViewHolder<ParticipatedProjectsData> {
        return ParticipatedProjectsViewHolder(parent)
    }
}
```
> 1. `BaseAdapter` 상속
>   - 해당 어댑터에서 사용할 데이터 모델을 제네릭으로 선언
> 2. `onCreateViewHolder`를 override
>   - 사용할 `ViewHolder`를 만들어 리턴하기만 하면 됨
>   - `onCreateViewHolder` 에서 받은 `parent: ViewGroup`를 파라미터로 넘겨줌

#### ViewHolder
```
class RoundmeetingViewHolder(parent: ViewGroup) : BaseViewHolder<RoundmeetingData>(R.layout.item_roundmeeting, parent) {
    val ImageView_added_card_roundmeeting = itemView.findViewById<ImageView>(R.id.ImageView_added_card_roundmeeting)

    override fun bind(data : RoundmeetingData){
        Glide.with(itemView).load(data.ImageView_added_card_roundmeeting).into(ImageView_added_card_roundmeeting)
    }
}
```

> 1. `BaseViewHolder` 상속
>   - 해당 뷰 홀더에서 사용할 데이터 모델을 제네릭으로 선언
>   - 해당 뷰 홀더에서 사용할 item layout의 layoutRes 를 파라미터로 넘겨줌
>   - 생성자로 받은 parent 또한 파라미터로 넘겨줌
> 2. `bind`를 override
>   - 매개변수로 받은 `data`가 해당 뷰 홀더에서 사용될 데이터 모델
>   - 하던대로 바인딩 해주면 된다.

#### 액티비티 (or 프래그먼트)에 적용할 때

```
participatedProjectsAdapter = ParticipatedProjectsAdapter()
recycler_participated_projects_list.adapter = participatedProjectsAdapter
```
> 파라미터 없이 어댑터 선언 및 적용

```
participatedProjectsAdapter.addAll(datas)
```
> 데이터 적용 시 addAll 메서드로 간편 사용
> notify 필요 없음

자세한 클래스 명세는 BaseAdapter, BaseViewHolder 를 열어보면 이해 가능함

적응하면 리사이클러뷰 5분만에 찍어내는 것 가능 !