### PR TITLE
feat: 메모 불러오기/저장하기 기능 추가

### DIFF
--- a/app/src/main/java/com/stormers/storm/card/adapter/SavedCardAdapter.kt
+++ b/app/src/main/java/com/stormers/storm/card/adapter/SavedCardAdapter.kt
@@ -12,6 +12,6 @@ class SavedCardAdapter(private val showHeart: Boolean, private val listener: OnC
     }
 
     interface OnCardClickListener {
-        fun onCardClick(projectIdx: Int, roundIdx: Int)
+        fun onCardClick(projectIdx: Int, roundIdx: Int, cardId: Int)
     }
 }

--- a/app/src/main/java/com/stormers/storm/card/repository/SavedCardRepository.kt
+++ b/app/src/main/java/com/stormers/storm/card/repository/SavedCardRepository.kt
@@ -21,7 +21,7 @@ class SavedCardRepository(val context: Context) : BaseRepository<SavedCardEntity
         return dao.getAll(projectIdx, roundIdx)
     }
 
-    fun getAllScarpedCard(projectIdx: Int): List<SavedCardEntity>? {
+    fun getAllScrapedCard(projectIdx: Int): List<SavedCardEntity>? {
         return dao.getAllScrapedCard(projectIdx)
     }
 

--- a/app/src/main/java/com/stormers/storm/card/viewholder/SavedCardViewHolder.kt
+++ b/app/src/main/java/com/stormers/storm/card/viewholder/SavedCardViewHolder.kt
@@ -20,7 +20,7 @@ class SavedCardViewHolder(parent: ViewGroup, private val showHeart: Boolean,
 
         listener?.let {
             itemView.setOnClickListener {
-                listener.onCardClick(data.projectIdx, data.roundIdx)
+                listener.onCardClick(data.projectIdx, data.roundIdx, data.cardId)
             }
         }
 

--- a/app/src/main/java/com/stormers/storm/round/base/BaseExpandCardActivity.kt
+++ b/app/src/main/java/com/stormers/storm/round/base/BaseExpandCardActivity.kt
@@ -1,0 +1,99 @@
+package com.stormers.storm.round.base
+
+import android.os.Bundle
+import androidx.viewpager2.widget.ViewPager2
+import com.stormers.storm.R
+import com.stormers.storm.base.BaseActivity
+import com.stormers.storm.card.adapter.ExpandCardAdapter
+import com.stormers.storm.card.model.SavedCardEntity
+import com.stormers.storm.card.repository.SavedCardRepository
+import com.stormers.storm.util.DepthPageTransformer
+import kotlinx.android.synthetic.main.activity_expandcard.*
+
+abstract class BaseExpandCardActivity(private val isScraped: Boolean): BaseActivity() {
+    private val expandCardAdapter: ExpandCardAdapter by lazy { ExpandCardAdapter() }
+
+    private val savedCardRepository: SavedCardRepository by lazy { SavedCardRepository(application) }
+
+    private var currentPage = 0
+
+    private var data: List<SavedCardEntity>? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_expandcard)
+
+        val projectIdx = intent.getIntExtra("projectIdx", 1)
+        val roundIdx = intent.getIntExtra("roundIdx", 1)
+        val cardId = intent.getIntExtra("cardId", 0)
+
+        data = initData(projectIdx, roundIdx, cardId)
+
+        initCurrentPage(cardId)
+
+        expandCardAdapter.addAll(data)
+
+        initViewPager()
+
+        stormbutton_expandcard_apply.setOnClickListener {
+
+            val updatedCard = expandCardAdapter.getItem(currentPage)
+            updatedCard.memo = edittext_expandcard_memo.text.toString()
+            savedCardRepository.update(updatedCard)
+
+            onApplied(updatedCard.cardId, updatedCard.memo)
+        }
+
+    }
+
+    private fun initViewPager() {
+        viewpager_fragment_card_expand.run {
+            adapter = expandCardAdapter
+            offscreenPageLimit = 3
+            setPageTransformer(DepthPageTransformer())
+            currentItem = currentPage
+
+            registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+                override fun onPageSelected(position: Int) {
+                    super.onPageSelected(position)
+                    currentPage = position
+
+                    setMemo(position)
+                }
+            })
+        }
+    }
+
+    private fun initCurrentPage(cardId: Int) {
+        if (data != null) {
+            for (i in data!!.indices) {
+                if (data!![i].cardId == cardId) {
+                    currentPage = i
+
+                    setMemo(currentPage)
+                    break
+                }
+            }
+        }
+    }
+
+    private fun setMemo(position: Int) {
+        data?.let {
+            if (it[position].memo != null) {
+                edittext_expandcard_memo.setText(it[position].memo)
+            } else {
+                edittext_expandcard_memo.text = null
+            }
+        }
+    }
+
+    private fun initData(projectIdx: Int, roundIdx: Int, cardId: Int): List<SavedCardEntity>? {
+        return  if (isScraped) {
+            savedCardRepository.getAllScrapedCard(projectIdx, roundIdx)
+        } else {
+            savedCardRepository.getAll(projectIdx, roundIdx)
+        }
+    }
+
+    abstract fun onApplied(cardId: Int, memo: String?)
+}

--- a/app/src/main/java/com/stormers/storm/ui/ParticipatedProjectDetailActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/ParticipatedProjectDetailActivity.kt
@@ -34,10 +34,11 @@ class ParticipatedProjectDetailActivity : BaseActivity() {
         }
 
         scrapedCardAdapter = SavedCardAdapter(false, object: SavedCardAdapter.OnCardClickListener {
-            override fun onCardClick(projectIdx: Int, roundIdx: Int) {
+            override fun onCardClick(projectIdx: Int, roundIdx: Int, cardId: Int) {
                 val intent = Intent(this@ParticipatedProjectDetailActivity, ScrapedCardDetailActivity::class.java)
                 intent.putExtra("projectIdx", projectIdx)
                 intent.putExtra("roundIdx", roundIdx)
+                intent.putExtra("cardId", cardId)
                 startActivity(intent)
             }
         })
@@ -46,7 +47,7 @@ class ParticipatedProjectDetailActivity : BaseActivity() {
         rv_scrap_card_part_detail.addItemDecoration(MarginDecoration(this, 15, RecyclerView.HORIZONTAL))
         rv_scrap_card_part_detail.addItemDecoration(MarginDecoration(this, 15, RecyclerView.VERTICAL))
 
-        scrapedCardAdapter.addAll(savedCardRepository.getAllScarpedCard(projectIdx))
+        scrapedCardAdapter.addAll(savedCardRepository.getAllScrapedCard(projectIdx))
 
         roundListAdapterForViewPager = RoundListAdapter(object : RoundListAdapter.OnRoundClickListener {
             override fun onRoundClick(projectIdx: Int, roundIdx: Int) {

--- a/app/src/main/java/com/stormers/storm/ui/RoundMeetingExpandActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/RoundMeetingExpandActivity.kt
@@ -1,34 +1,15 @@
 package com.stormers.storm.ui
 
 import android.os.Bundle
-import com.stormers.storm.R
-import com.stormers.storm.base.BaseActivity
-import com.stormers.storm.card.adapter.ExpandCardAdapter
-import com.stormers.storm.card.repository.SavedCardRepository
-import com.stormers.storm.util.DepthPageTransformer
-import kotlinx.android.synthetic.main.activity_expandcard.*
+import com.stormers.storm.round.base.BaseExpandCardActivity
 
-class RoundMeetingExpandActivity : BaseActivity() {
-
-    private val expandCardAdapter: ExpandCardAdapter by lazy { ExpandCardAdapter() }
-
-    private val savedCardRepository: SavedCardRepository by lazy { SavedCardRepository(application) }
+class RoundMeetingExpandActivity : BaseExpandCardActivity(false) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_expandcard)
+    }
 
-        val projectIdx = intent.getIntExtra("projectIdx", 1)
-        val roundIdx = intent.getIntExtra("roundIdx", 1)
-
-        expandCardAdapter.addAll(savedCardRepository.getAll(projectIdx, roundIdx))
-        
-        viewpager_fragment_card_expand.run {
-            adapter = expandCardAdapter
-            offscreenPageLimit = 3
-            setPageTransformer(DepthPageTransformer())
-            currentItem = roundIdx
-        }
-
+    override fun onApplied(cardId: Int, memo: String?) {
+        //Todo: 서버로 전송
     }
 }

--- a/app/src/main/java/com/stormers/storm/ui/ScrapedCardDetailActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/ScrapedCardDetailActivity.kt
@@ -1,28 +1,16 @@
 package com.stormers.storm.ui
 
 import android.os.Bundle
-import android.view.View
-import android.widget.Toast
-import com.stormers.storm.R
-import com.stormers.storm.base.BaseActivity
-import com.stormers.storm.card.fragment.ScrapcardDetailFragment
-import kotlinx.android.synthetic.main.activity_round_progress.*
+import com.stormers.storm.round.base.BaseExpandCardActivity
 
-class ScrapedCardDetailActivity : BaseActivity() {
+class ScrapedCardDetailActivity : BaseExpandCardActivity(true) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_round_progress)
-        goToFragment(ScrapcardDetailFragment::class.java, null)
-
-        button_save_round_progress.visibility = View.VISIBLE
-        button_save_round_progress.setOnClickListener {
-            Toast.makeText(this, "카드가 추가되었습니다", Toast.LENGTH_SHORT).show()
-        }
 
     }
 
-    override fun initFragmentId(): Int? {
-        return R.id.framelayout_roundprogress_fragment
+    override fun onApplied(cardId: Int, memo: String?) {
+        //Todo: memo 서버로 전송
     }
 }

--- a/app/src/main/res/layout/activity_expandcard.xml
+++ b/app/src/main/res/layout/activity_expandcard.xml
@@ -94,6 +94,7 @@
         app:layout_constraintTop_toBottomOf="@+id/viewpager_fragment_card_expand">
 
         <EditText
+            android:id="@+id/edittext_expandcard_memo"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="top|start"
@@ -108,6 +109,7 @@
     </androidx.cardview.widget.CardView>
 
     <com.stormers.storm.customview.StormButton
+        android:id="@+id/stormbutton_expandcard_apply"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:elevation="10dp"


### PR DESCRIPTION
BaseClass로 중복코드도 해결했어 ~~

`RoundMeetingExpandActivity`에서는 `BaseExpandCardActivity(false)`를 상속하고
`ScrapedCardDetailActivity`에서는 `BaseExpandCardActivity(true)`를 상속해야해!

액티비티 내에서는 별도의 코드가 필요없고 `onApplied()` 메서드만 재정의하면 되겠다 (아직까지는)

그리고 프로젝트 상세보기 뷰에서 스크랩한 카드를 누르면 그 카드를 먼저 띄워야 하기 때문에 `SavedCardAdapter.OnCardClickListener`의 `onCardClick()`의 파라미터가 늘었어! cardId도 받도록 했어 !