### PR TITLE
fix: 라운드 목표 시간을 두 번 눌러야 다이얼로그가 띄워지던 문제 수정

### DIFF
--- a/app/src/main/res/layout/fragment_host_round_setting.xml
+++ b/app/src/main/res/layout/fragment_host_round_setting.xml
@@ -58,6 +58,7 @@
         android:layout_marginTop="14dp"
         android:hint="라운드 소요 시간"
         style="@style/custom_editText"
+        android:focusable="false"
         android:foreground="?android:selectableItemBackground"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/textview_round_goal"


### PR DESCRIPTION
정확하게 이해하진 못했지만 포커스 관련한 문제 때문에 두 번 눌러야했었나봐

이전에는 한 번 누르면 포커스를 갖고, 이후에 한 번 또 눌러야 리스너가 작동했는데

포커스를 갖지 않도록 설정해서 한 번 누르면 바로 리스너를 작동하도록 했어 !

속성 한 줄 추가하면 되는 건데 한참 찾았네 ~.~