### PR TITLE
fix: 참여한 프로젝트 터치가 안먹는 문제 수정

### DIFF
--- a/app/src/main/java/com/stormers/storm/customview/ClickableRecyclerView.kt
+++ b/app/src/main/java/com/stormers/storm/customview/ClickableRecyclerView.kt
@@ -1,0 +1,53 @@
+package com.stormers.storm.customview
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
+import androidx.recyclerview.widget.RecyclerView
+
+class ClickableRecyclerView : ConstraintLayout {
+
+    constructor(context: Context) : super(context)
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    val recyclerView = RecyclerView(context)
+
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        return true
+    }
+
+    init {
+        recyclerView.id = View.generateViewId()
+        this.addView(recyclerView)
+        ConstraintSet().also { cs ->
+            cs.clone(this)
+            cs.connect(
+                recyclerView.id,
+                ConstraintSet.LEFT,
+                ConstraintSet.PARENT_ID,
+                ConstraintSet.LEFT,
+                0
+            )
+            cs.connect(
+                recyclerView.id,
+                ConstraintSet.TOP,
+                ConstraintSet.PARENT_ID,
+                ConstraintSet.TOP,
+                0
+            )
+            cs.applyTo(this)
+        }
+
+        recyclerView.layoutParams.apply {
+            width = LayoutParams.MATCH_PARENT
+            height = LayoutParams.MATCH_PARENT
+        }
+    }
+
+}

--- a/app/src/main/java/com/stormers/storm/project/viewholder/ParticipatedProjectViewHolder.kt
+++ b/app/src/main/java/com/stormers/storm/project/viewholder/ParticipatedProjectViewHolder.kt
@@ -1,6 +1,7 @@
 package com.stormers.storm.project.viewholder
 
 import android.view.ViewGroup
+import androidx.recyclerview.widget.GridLayoutManager
 import com.stormers.storm.R
 import com.stormers.storm.base.BaseViewHolder
 import com.stormers.storm.card.adapter.CardPreviewAdapter
@@ -38,8 +39,9 @@ class ParticipatedProjectViewHolder(parent: ViewGroup, private val isMain: Boole
     }
 
     private fun initCardImage(data: ParticipatedProjectModel) {
-        itemView.recyclerview_projectfolder.run {
+        itemView.recyclerview_projectfolder.recyclerView.run {
             adapter = cardPreviewAdapter
+            layoutManager = GridLayoutManager(context, 2)
             addItemDecoration(MiddleDividerItemDecoration(context, MiddleDividerItemDecoration.VERTICAL))
             addItemDecoration(MiddleDividerItemDecoration(context, MiddleDividerItemDecoration.HORIZONTAL))
         }

--- a/app/src/main/res/layout/item_participated_projects_list.xml
+++ b/app/src/main/res/layout/item_participated_projects_list.xml
@@ -19,11 +19,8 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
-        <androidx.recyclerview.widget.RecyclerView
+        <com.stormers.storm.customview.ClickableRecyclerView
             android:id="@+id/recyclerview_projectfolder"
-            app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
-            app:spanCount="2"
-            tools:itemCount="4"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
 


### PR DESCRIPTION
메인 화면 참여한 프로젝트 목록 터치가 안먹는 문제 수정했어

리사이클러뷰 자체가 터치 이벤트를 가져가버리기 때문에 이를 비활성화 하는 뷰그룹을 둘러싼 형태의 커스텀뷰를 만들어서 사용했어 !