### PR TITLE
fix: 첫 화면에서는 라운드 정보가 초기화 되지 않는 문제 해결

### DIFF
--- a/app/src/main/java/com/stormers/storm/ui/ScrapedCardExpandActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/ScrapedCardExpandActivity.kt
@@ -35,7 +35,9 @@ class ScrapedCardExpandActivity : BaseActivity(), ExpandCardFragment.OnCardPageC
         val selectedProjectIdx = intent.getIntExtra("projectIdx", -1)
         val selectedProjectName = intent.getStringExtra("projectName")
 
-        initView(selectedProjectName)
+        initProjectInfo(selectedProjectName)
+
+        initRoundInfoOfCard(selectedCardIdx)
 
         goToFragment(ExpandCardFragment::class.java, Bundle().apply {
             if (selectedCardIdx != -1) {
@@ -49,30 +51,33 @@ class ScrapedCardExpandActivity : BaseActivity(), ExpandCardFragment.OnCardPageC
     }
 
     override fun onCardPageChanged(position: Int, totalCount: Int, cardModel: CardModel) {
-        cardRepository.get(cardModel.cardIdx, object : CardRepository.GetCardModel<CardEntity> {
-            override fun onCardLoaded(card: CardEntity) {
-                getRoundData(card.roundIdx)
-            }
-
-            @SuppressLint("LongLogTag")
-            override fun onDataNotAvailable() {
-                Log.e(TAG, "onCardPageChanged: No card data. cardIdx (${cardModel.cardIdx}")
-            }
-        })
-
+        initRoundInfoOfCard(cardModel.cardIdx)
     }
 
     override fun initFragmentId(): Int? {
         return R.id.framelayout_expandcard_fragment
     }
 
-    private fun initView(projectName: String?) {
+    private fun initProjectInfo(projectName: String?) {
         textview_expandcard_count.visibility = View.GONE
 
         textview_expandcard_projectname.text = projectName
     }
 
-    private fun getRoundData(roundIdx: Int) {
+    private fun initRoundInfoOfCard(cardIdx: Int) {
+        cardRepository.get(cardIdx, object : CardRepository.GetCardModel<CardEntity> {
+            override fun onCardLoaded(card: CardEntity) {
+                initRoundInfo(card.roundIdx)
+            }
+
+            @SuppressLint("LongLogTag")
+            override fun onDataNotAvailable() {
+                Log.e(TAG, "onCardPageChanged: No card data. cardIdx (${cardIdx}")
+            }
+        })
+    }
+
+    private fun initRoundInfo(roundIdx: Int) {
         if (cacheRoundData.containsKey(roundIdx)) {
             setRoundData(cacheRoundData[roundIdx]!!)
             return


### PR DESCRIPTION
간단한 버그 수정이야

스크랩한 카드 상세히 보기 뷰는 라운드에 상관없이 프로젝트에서 스크랩한 카드들이 모두 보이기 때문에 각자 다른 라운드 정보를 가질 수 있어

그래서 스크롤 할 때 마다 해당 카드가 포함된 라운드의 정보를 불러와 보여주는데 가장 처음 진입할 때에는 이게 초기화되지 않더라고 !

뷰페이저가 스크롤 될 때 실행되는 콜백에 작성한 내용을 메서드로 붂어서 뷰가 초기화될 때 한 번 더 호출해줬어