### PR TITLE
fix: 라운드 종료되는 찰나에 카드를 추가하면 튕기는 버그 수정

### DIFF
--- a/app/src/main/java/com/stormers/storm/canvas/fragment/CanvasDrawingFragment.kt
+++ b/app/src/main/java/com/stormers/storm/canvas/fragment/CanvasDrawingFragment.kt
@@ -146,7 +146,9 @@ class CanvasDrawingFragment : BaseCanvasFragment(DRAWING_MODE, R.layout.view_dra
     private fun saveCard(bitmap: Bitmap) {
         val card = CardEnumModel(0, userIdx, projectIdx, false,
             CardType.DRAWING, BitmapConverter.bitmapToString(bitmap))
-        (mActivity as RoundProgressActivity).cardList.add(card)
+        if (mActivity != null) {
+            (mActivity as RoundProgressActivity).cardList.add(card)
+        }
     }
 
     private fun setEnableUndoButton(isEnable: Boolean) {

--- a/app/src/main/java/com/stormers/storm/canvas/fragment/CanvasTextFragment.kt
+++ b/app/src/main/java/com/stormers/storm/canvas/fragment/CanvasTextFragment.kt
@@ -67,6 +67,9 @@ class CanvasTextFragment : BaseCanvasFragment(TEXT_MODE, R.layout.view_addcard_e
     }
 
     private fun saveCard(content: String) {
-        (mActivity as RoundProgressActivity).cardList.add(CardEnumModel(0, projectIdx, roundIdx, false, CardType.TEXT, content))
+        val card = CardEnumModel(0, projectIdx, roundIdx, false, CardType.TEXT, content)
+        if (mActivity != null) {
+            (mActivity as RoundProgressActivity).cardList.add(card)
+        }
     }
 }


### PR DESCRIPTION
라운드가 종료되려고 하는 순간에 카드를 추가하면 비정상 종료되는 문제가 있었어

원인은

카드 추가 --> 서버 전송 --> 응답 --> 액티비티에 보여줌 
위 과정을 거치는데 서버에 전송하고 응답을 받는 동안 라운드가 종료되고 액티비티가 반환되면, 액티비티가 null이 되기 때문이었어
그래서 액티비티가 null인지 판단한 후에 추가할 수 있도록 예외처리를 추가했지