### PR TITLE
feat: 스크랩한 카드가 없을 땐 더 보기 버튼을 숨기기

### DIFF
--- a/app/src/main/java/com/stormers/storm/ui/ParticipatedProjectDetailActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/ParticipatedProjectDetailActivity.kt
@@ -146,6 +146,7 @@ class ParticipatedProjectDetailActivity : BaseActivity() {
 
             override fun onDataNotAvailable() {
                 recyclerview_participateddetail_scrapedcard.visibility = View.GONE
+                constraintlayout_participatedproject_seemore.visibility = View.GONE
                 textview_participateddetail_noscraped.visibility = View.VISIBLE
             }
         })


### PR DESCRIPTION
너무 간단해서 민망한 수준의 브랜치.

스크랩한 카드가 없을 땐 더 보기 버튼이 보이지 않아야한대