### PR TITLE
Feature/loading dialog

### DIFF
--- a/app/src/main/java/com/stormers/storm/base/BaseActivity.kt
+++ b/app/src/main/java/com/stormers/storm/base/BaseActivity.kt
@@ -5,16 +5,19 @@ import android.os.Bundle
 import android.view.MotionEvent
 import android.view.inputmethod.InputMethodManager
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
-import com.stormers.storm.R
+import com.stormers.storm.customview.dialog.StormLoadingDialog
 import com.stormers.storm.ui.GlobalApplication
 import com.stormers.storm.util.SharedPreference
 
 abstract class BaseActivity : AppCompatActivity() {
 
     private var fragmentId: Int? = null
-    
+
     protected val preference: SharedPreference by lazy { GlobalApplication.prefs }
+
+    private val loadingDialog: DialogFragment by lazy { StormLoadingDialog() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,16 +25,16 @@ abstract class BaseActivity : AppCompatActivity() {
         fragmentId = initFragmentId()
     }
 
-    protected open fun initFragmentId() : Int? {
+    protected open fun initFragmentId(): Int? {
         return null
     }
 
     fun showLoadingDialog() {
-        //Todo: 로딩 다이얼로그 띄우기
+        loadingDialog.show(supportFragmentManager, "loading_dialog")
     }
 
-    fun hideLoadingDialog() {
-        //Todo: 로딩 다이얼로그 닫기
+    fun dismissLoadingDialog() {
+        loadingDialog.dismiss()
     }
 
     fun goToFragment(cls: Class<*>, args: Bundle?) {
@@ -44,6 +47,7 @@ abstract class BaseActivity : AppCompatActivity() {
             e.printStackTrace()
         }
     }
+
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
         if (currentFocus != null) {
             val imm = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager

--- a/app/src/main/java/com/stormers/storm/base/BaseFragment.kt
+++ b/app/src/main/java/com/stormers/storm/base/BaseFragment.kt
@@ -34,8 +34,8 @@ abstract class BaseFragment() : Fragment() {
         (activity as? BaseActivity)?.showLoadingDialog()
     }
 
-    fun hideLoadingDialog() {
-        (activity as? BaseActivity)?.hideLoadingDialog()
+    fun dismissLoadingDialog() {
+        (activity as? BaseActivity)?.dismissLoadingDialog()
     }
 
 }

--- a/app/src/main/java/com/stormers/storm/canvas/fragment/CanvasDrawingFragment.kt
+++ b/app/src/main/java/com/stormers/storm/canvas/fragment/CanvasDrawingFragment.kt
@@ -100,6 +100,8 @@ class CanvasDrawingFragment : BaseCanvasFragment(DRAWING_MODE, R.layout.view_dra
     }
 
     private fun sendBitmap(bitmap: Bitmap) {
+        showLoadingDialog()
+
         val drawingFile = BitmapConverter.bitmapToFile(bitmap, context!!.cacheDir.toString())
 
         val requestFile = RequestBody.create(MediaType.parse("multipart/form-data"), drawingFile!!)
@@ -116,10 +118,12 @@ class CanvasDrawingFragment : BaseCanvasFragment(DRAWING_MODE, R.layout.view_dra
             .enqueue(object: Callback<Response> {
 
                 override fun onFailure(call: Call<Response>, t: Throwable) {
+                    dismissLoadingDialog()
                     Log.d("postCard", t.message)
                 }
 
                 override fun onResponse(call: Call<Response>, response: retrofit2.Response<Response>) {
+                    dismissLoadingDialog()
                     if (response.isSuccessful) {
                         if (response.body()!!.success) {
 
@@ -140,7 +144,6 @@ class CanvasDrawingFragment : BaseCanvasFragment(DRAWING_MODE, R.layout.view_dra
     private fun afterResponse() {
         drawview.clearDrawAndHistory()
         Toast.makeText(context, "카드가 추가되었습니다", Toast.LENGTH_SHORT).show()
-        goToFragment(AddCardFragment::class.java, null)
     }
 
     private fun saveCard(bitmap: Bitmap) {

--- a/app/src/main/java/com/stormers/storm/canvas/fragment/CanvasTextFragment.kt
+++ b/app/src/main/java/com/stormers/storm/canvas/fragment/CanvasTextFragment.kt
@@ -27,6 +27,7 @@ class CanvasTextFragment : BaseCanvasFragment(TEXT_MODE, R.layout.view_addcard_e
     override fun onApplied() {
         val content = edittext_addcard.text.toString()
         if (!content.isBlank()) {
+            showLoadingDialog()
 
             val userIdx = RequestBody.create(MediaType.parse("text/plain"), userIdx.toString())
 
@@ -40,19 +41,18 @@ class CanvasTextFragment : BaseCanvasFragment(TEXT_MODE, R.layout.view_addcard_e
                 .postCard(userIdx, projectIdx, roundIdx, null, cardText).enqueue(object : Callback<Response> {
 
                     override fun onFailure(call: Call<Response>, t: Throwable) {
+                        dismissLoadingDialog()
                         Log.d(TAG, "postCard : Fail, ${t.message}")
                     }
 
                     override fun onResponse(call: Call<Response>, response: retrofit2.Response<Response>) {
+                        dismissLoadingDialog()
                         if (response.isSuccessful) {
                             if (response.body()!!.success) {
 
                                 saveCard(content)
 
                                 Toast.makeText(context, "카드가 추가되었습니다", Toast.LENGTH_SHORT).show()
-
-                                goToFragment(AddCardFragment::class.java, null)
-
                             } else {
                                 Log.d(TAG, "postCard: Not success, ${response.body()!!.message}")
                             }

--- a/app/src/main/java/com/stormers/storm/customview/dialog/StormLoadingDialog.kt
+++ b/app/src/main/java/com/stormers/storm/customview/dialog/StormLoadingDialog.kt
@@ -1,0 +1,33 @@
+package com.stormers.storm.customview.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import com.stormers.storm.R
+
+class StormLoadingDialog : DialogFragment() {
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        dialog?.requestWindowFeature(Window.FEATURE_NO_TITLE)
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        isCancelable = false
+
+        return inflater.inflate(R.layout.layout_loading_animation, container, false)
+    }
+
+    override fun show(manager: FragmentManager, tag: String?) {
+        try {
+            val ft = manager.beginTransaction()
+            ft.add(this, tag)
+            ft.commitAllowingStateLoss()
+        } catch (ignored: IllegalStateException) {
+
+        }
+    }
+}

--- a/app/src/main/java/com/stormers/storm/round/base/BaseWaitingFragment.kt
+++ b/app/src/main/java/com/stormers/storm/round/base/BaseWaitingFragment.kt
@@ -69,6 +69,8 @@ abstract class BaseWaitingFragment(@LayoutRes layoutRes: Int) : BaseFragment(lay
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        showLoadingDialog()
+
         isFirstRound = arguments?.getBoolean("isFirstRound") ?: true
 
         val isPromotion = arguments?.getBoolean("isPromotion") ?: false
@@ -174,10 +176,12 @@ abstract class BaseWaitingFragment(@LayoutRes layoutRes: Int) : BaseFragment(lay
             .enqueue(object : Callback<ResponseProjectUserListModel> {
 
                 override fun onFailure(call: Call<ResponseProjectUserListModel>, t: Throwable) {
+                    dismissLoadingDialog()
                     Log.d(TAG, "getParticipants : fail, ${t.message}")
                     callback.onDataNotAvailable()
                 }
                 override fun onResponse(call: Call<ResponseProjectUserListModel>, response: Response<ResponseProjectUserListModel>) {
+                    dismissLoadingDialog()
                     if (response.isSuccessful) {
                         if (response.body()!!.success) {
                             val result = response.body()!!.data

--- a/app/src/main/java/com/stormers/storm/ui/LoginActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/LoginActivity.kt
@@ -43,12 +43,15 @@ class LoginActivity : BaseActivity() {
                     preference.setAutoLogIn(false)
                 }
 
+                showLoadingDialog()
+
                 RetrofitClient.create(RequestLogIn::class.java).requestLogIn(
                     LogInModel(
                         edittext_email_login.text.toString(),
                         edittext_password_login.text.toString())
                 ).enqueue(object :retrofit2.Callback<ResponseLogIn>{
                     override fun onFailure(call: Call<ResponseLogIn>, t: Throwable) {
+                        dismissLoadingDialog()
                         Log.d("로그인 실패", t.message)
                     }
 
@@ -56,6 +59,7 @@ class LoginActivity : BaseActivity() {
                         call: Call<ResponseLogIn>,
                         response: Response<ResponseLogIn>
                     ) {
+                        dismissLoadingDialog()
                         if(response.isSuccessful){
                             if (response.body()!!.success){
                                 Log.d("userIdx", response.body()!!.data.toString())

--- a/app/src/main/java/com/stormers/storm/ui/SignUpActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/SignUpActivity.kt
@@ -354,6 +354,8 @@ class SignUpActivity : BaseActivity() {
 
         button_complete_signup.setOnClickListener{
 
+            showLoadingDialog()
+
             saveProfile()
             GlobalApplication.profileBitmap = profileBitmap
 
@@ -374,13 +376,14 @@ class SignUpActivity : BaseActivity() {
             RetrofitClient.create(InterfaceSignUp::class.java).interfaceSignUp(sendUserImage, userName,userEmail,userPassword, userImageFlag)
                 .enqueue(object : Callback<ResponseSignUpModel> {
                     override fun onFailure(call: Call<ResponseSignUpModel>, t: Throwable) {
-
+                        dismissLoadingDialog()
                     }
 
                     override fun onResponse(
                         call: Call<ResponseSignUpModel>,
                         response: Response<ResponseSignUpModel>
                     ) {
+                        dismissLoadingDialog()
                         if(response.isSuccessful){
                             if (response.body()!!.success){
 

--- a/app/src/main/res/layout/layout_loading_animation.xml
+++ b/app/src/main/res/layout/layout_loading_animation.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.airbnb.lottie.LottieAnimationView
+        android:layout_width="80dp"
+        android:layout_height="28dp"
+        app:lottie_autoPlay="true"
+        app:lottie_loop="true"
+        app:lottie_rawRes="@raw/loading_animation"
+        android:layout_gravity="center"
+        />
+
+</FrameLayout>


### PR DESCRIPTION
로딩 다이얼로그 추가했어

혹시 필요하다 싶으면 어떤 액티비티든, 어떤 프래그먼트든 베이스 액티비티/프래그먼트를 상속했다면

`showLoadingDialog()` 와 `dismissLoadingDialog()` 를 호출하면돼

사용된 곳
- 라운드 진행 중 카드를 만들고 추가 버튼을 눌러 서버에 전송할 때
- 회원가입 완료 버튼을 누를 때
- 로그인 버튼을 누를 때
- 라운드 대기방 처음 입장 후 참가자 최초 로딩 전 까지

위에서 세 상황은 bitmap 통신이 있기 때문에 다른 통신보다 속도가 조금 느리고, 버튼 클릭 시 행하는 로직이 무거워서 실수로 두 번 누르는 걸 방지하기 위해서 넣었어 !
마지막 하나는 참가자가 아직 로딩되지 않은 상황에서 라운드 시작을 눌러버리면 참가자가 DB에 저장되지 못해서 모든 카드가 로딩되지 못해

+ 현지 피드백으로 카드 추가 후 그 프래그먼트에 그대로 머물도록 했어