### PR TITLE
feat: 세로모드 고정, 혹여 바뀌더라도 액티비티 재생성하지 못하도록 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,13 +47,15 @@
         <activity
             android:name=".ui.MainActivity"
             android:windowSoftInputMode="adjustNothing" />
-        <activity android:name=".ui.MemberRoundWaitingActivity" />
+        <activity android:name=".ui.MemberRoundWaitingActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"/>
         <activity android:name=".ui.ParticipatedProjectListActivity" />
         <activity android:name=".ui.ParticipatedProjectDetailActivity" />
         <activity android:name=".ui.HostRoundFinishActivity" />
         <activity android:name=".ui.RoundListActivity" />
         <activity android:name=".ui.RoundProgressActivity" />
-        <activity android:name=".ui.HostRoundSettingActivity" />
+        <activity android:name=".ui.HostRoundSettingActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize"/>
         <activity android:name=".ui.ScrapCardCollectingActivity" />
         <activity
             android:name=".ui.MypageActivity"

--- a/app/src/main/java/com/stormers/storm/round/base/BaseRoundWaitingActivity.kt
+++ b/app/src/main/java/com/stormers/storm/round/base/BaseRoundWaitingActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -29,6 +30,10 @@ open class BaseRoundWaitingActivity : BaseActivity() {
     }
 
     private val exitDialogButtons: ArrayList<StormDialogButton> by lazy { ArrayList<StormDialogButton>() }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/stormers/storm/ui/GlobalApplication.kt
+++ b/app/src/main/java/com/stormers/storm/ui/GlobalApplication.kt
@@ -1,7 +1,11 @@
 package com.stormers.storm.ui
 
+import android.app.Activity
 import android.app.Application
+import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.os.Bundle
 import com.kakao.auth.KakaoSDK
 import com.stormers.storm.kakao.KakaoSDKAdapter
 import com.stormers.storm.project.model.ProjectEntity
@@ -20,6 +24,34 @@ class GlobalApplication : Application() {
 
         prefs = SharedPreference(applicationContext)
         databaseManager = DatabaseManager.getInstance(this)
+
+        registerActivityLifecycleCallbacks(object: ActivityLifecycleCallbacks {
+            override fun onActivityCreated(activity: Activity?, savedInstanceState: Bundle?) {
+                activity?.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+            }
+
+            override fun onActivityPaused(activity: Activity?) {
+            }
+
+            override fun onActivityResumed(activity: Activity?) {
+            }
+
+            override fun onActivityDestroyed(activity: Activity?) {
+            }
+
+            override fun onActivitySaveInstanceState(activity: Activity?, outState: Bundle?) {
+            }
+
+            override fun onActivityStarted(activity: Activity?) {
+            }
+
+            override fun onActivityStopped(activity: Activity?) {
+            }
+        })
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
     }
 
     override fun onTerminate() {


### PR DESCRIPTION
다른 곳은 괜찮은데 라운드 대기방에서 가로모드가 되면, 액티비티가 재생성되면서 NPE가 발생했어

같은 이유로 스크린샷을 찍으면 액티비티가 재생성되는 디바이스도 있는 것 같길래

1. 세로모드 고정
2. 화면에 변화가 있어도 (화면 전환, 스크린샷) 액티비티를 재생성하지 않도록 함

위 수정으로 비정상 종료를 방지했어 !