### PR TITLE
fix: 호스트로 승격한 경우라도 라운드 정보를 초기화하도록 함

### DIFF
--- a/app/src/main/java/com/stormers/storm/round/fragment/HostRoundWaitingFragment.kt
+++ b/app/src/main/java/com/stormers/storm/round/fragment/HostRoundWaitingFragment.kt
@@ -32,6 +32,11 @@ class HostRoundWaitingFragment : BaseWaitingFragment(R.layout.fragment_hostwaiti
         //확인 버튼 초기화
         initActivityButton()
 
+        //라운드 정보 초기화
+        GlobalApplication.currentRound?.let {
+            initRoundInfo(it.roundPurpose!!, it.roundTime!!, it.roundNumber!!)
+        }
+
         //호스트로 승급한 경우에는 아래 초기화 코드들을 실행하지 않음
         if (isPromotion != null && isPromotion) {
             return
@@ -40,11 +45,6 @@ class HostRoundWaitingFragment : BaseWaitingFragment(R.layout.fragment_hostwaiti
         //첫 번째 라운드가 아니라면 라운드가 시작됨을 소켓으로 알림
         if (!isFirstRound) {
             startRoundAgain()
-        }
-
-        //라운드 정보 초기화
-        GlobalApplication.currentRound?.let {
-            initRoundInfo(it.roundPurpose!!, it.roundTime!!, it.roundNumber!!)
         }
     }
 


### PR DESCRIPTION
호스트로 승격해서 액티비티를 전환하면, 중복되는 초기화는 하지 않으려고 했는데 실수로 라운드 정보 초기화를 거기에 포함시켰어 !

그 부분 간단히 수정했어 ~