### PR TITLE
fix: 5명 이상의 참가자가 있던 프로젝트를 조회할 때 튕기던 문제 수정

### DIFF
--- a/app/src/main/java/com/stormers/storm/round/base/BaseRoundViewHolder.kt
+++ b/app/src/main/java/com/stormers/storm/round/base/BaseRoundViewHolder.kt
@@ -39,13 +39,14 @@ open class BaseRoundViewHolder (parent: ViewGroup, @LayoutRes val layoutRes: Int
                 recyclerview_user_profile.adapter = projectParticipantsAdapter
 
                 projectParticipantsAdapter.setList(data.participants!!)
+            }
 
-                val numberOfParticipants = data.participants!!.size
-                if( numberOfParticipants > 5 ) {
-                    textview_extra_participants_info.run {
-                        visibility = View.VISIBLE
-                        text = StringBuilder("+").append(numberOfParticipants - 5).toString()
-                    }
+            val numberOfParticipants = data.participants!!.size
+
+            if( numberOfParticipants > 5 ) {
+                textview_extra_participants_info.run {
+                    visibility = View.VISIBLE
+                    text = StringBuilder("+").append(numberOfParticipants - 5).toString()
                 }
             }
         }


### PR DESCRIPTION
참가자 목록이 많아지면 +n 되던 부분에서 레이아웃 참조가 잘못 되어 있었어 (내 잘못)

그래서 5명 이상일 때 이 부분의 코드가 실행되면 비정상 종료되었더라

이것이 어떤 프로젝트는 조회하면 튕기고 그랬던 것의 원인으로 분석됨! 참조 제대로 수정했어