### PR TITLE
fix: 앱 삭제 시 sharedPreference 데이터 삭제

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,9 @@
 
     <application
         android:name=".ui.GlobalApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:fullBackupContent="false"
+        android:fullBackupOnly="false"
         android:icon="@mipmap/storm_app_icon"
         android:label="STORM"
         android:largeHeap="true"
@@ -18,7 +20,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true"
-        toos:replace="android:label">
+        toos:replace="android:label,android:allowBackup">
         <activity android:name=".ui.RoundCardExpandActivity"></activity>
         <activity android:name=".ui.ScrapedRoundCardExpandActivity" />
         <activity android:name=".ui.MemberRoundFinishActivity" />


### PR DESCRIPTION
성규씨가 보내준 포스팅 참고해서 추가했습니다!! 앱 삭제 후 다시 설치하면 sharedPreference의 데이터가 삭제되고 바로 로그인뷰로 넘어갑니다!!