### PR TITLE
refator: 글<->그림 전환 시 다이얼로그 안뜨도록, 내용 남도록

### DIFF
--- a/app/src/main/java/com/stormers/storm/base/BaseActivity.kt
+++ b/app/src/main/java/com/stormers/storm/base/BaseActivity.kt
@@ -41,12 +41,45 @@ abstract class BaseActivity : AppCompatActivity() {
         loadingDialog.dismiss()
     }
 
-    fun goToFragment(cls: Class<*>, args: Bundle?) {
+    fun goToFragment(cls: Class<*>, args: Bundle?): Fragment? {
         try {
             val fragment = cls.newInstance() as Fragment
             fragment.arguments = args
             val fragmentManager = supportFragmentManager
             fragmentManager.beginTransaction().replace(fragmentId!!, fragment).commit()
+            return fragment
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return null
+    }
+
+    fun addFragment(cls: Class<*>, args: Bundle?) : Fragment? {
+        try {
+            val fragment = cls.newInstance() as Fragment
+            fragment.arguments = args
+            val fragmentManager = supportFragmentManager
+            fragmentManager.beginTransaction().add(fragmentId!!, fragment).commit()
+            return fragment
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return null
+    }
+
+    fun hideFragment(fragment: Fragment) {
+        try {
+            val fragmentManager = supportFragmentManager
+            fragmentManager.beginTransaction().hide(fragment).commit()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    fun showFragment(fragment: Fragment) {
+        try {
+            val fragmentManager = supportFragmentManager
+            fragmentManager.beginTransaction().show(fragment).commit()
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/app/src/main/java/com/stormers/storm/canvas/base/BaseCanvasFragment.kt
+++ b/app/src/main/java/com/stormers/storm/canvas/base/BaseCanvasFragment.kt
@@ -1,7 +1,5 @@
 package com.stormers.storm.canvas.base
 
-import android.app.Activity
-import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -9,13 +7,7 @@ import android.widget.Toast
 import androidx.annotation.LayoutRes
 import com.stormers.storm.R
 import com.stormers.storm.card.fragment.AddCardFragment
-import com.stormers.storm.base.BaseFragment
-import com.stormers.storm.customview.dialog.StormDialogBuilder
-import com.stormers.storm.customview.dialog.StormDialogButton
-import com.stormers.storm.canvas.fragment.CanvasDrawingFragment
-import com.stormers.storm.canvas.fragment.CanvasTextFragment
 import com.stormers.storm.round.base.BaseRoundFragment
-import com.stormers.storm.ui.GlobalApplication
 import com.stormers.storm.ui.RoundProgressActivity
 import kotlinx.android.synthetic.main.activity_round_progress.*
 import kotlinx.android.synthetic.main.fragment_round_canvas.*
@@ -29,41 +21,45 @@ abstract class BaseCanvasFragment(private val mode: Int, @LayoutRes private val 
     }
 
     private lateinit var targetModeStr: String
-    private lateinit var targetFragment: Class<*>
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         LayoutInflater.from(context).inflate(canvasLayout, cardview_roundcanvas_canvas)
 
-        (mActivity as RoundProgressActivity).stormtoolbar_roundprogress.setBackButton(View.OnClickListener {
-            goToFragment(AddCardFragment::class.java, null)
-        })
+        (mActivity as RoundProgressActivity).run {
+            stormtoolbar_roundprogress.setBackButton(View.OnClickListener {
+                goToFragment(AddCardFragment::class.java, null)
+            })
+        }
 
         initCanvas()
 
         when (mode) {
             DRAWING_MODE -> {
                 targetModeStr = "글 "
-                targetFragment = CanvasTextFragment::class.java
 
                 imagebutton_change_text.alpha = 0.5f
 
                 imagebutton_change_text.setOnClickListener {
-                    showChangeDialog()
+                    (mActivity as RoundProgressActivity).run {
+                        showFragment(canvasTextFragment!!)
+                        hideFragment(this@BaseCanvasFragment)
+                    }
                 }
             }
 
             else -> {
                 targetModeStr = "그림 "
-                targetFragment = CanvasDrawingFragment::class.java
 
                 imagebutton_change_draw.alpha = 0.5f
 
                 imagebutton_change_draw.setOnClickListener {
-                    showChangeDialog()
+                    (mActivity as RoundProgressActivity).run {
+                        showFragment(canvasDrawingFragment!!)
+                        hideFragment(this@BaseCanvasFragment)
+                    }
                 }
-
                 group_canvas_unredo.visibility = View.INVISIBLE
             }
         }
@@ -76,24 +72,6 @@ abstract class BaseCanvasFragment(private val mode: Int, @LayoutRes private val 
             onTrashed()
             Toast.makeText(context, "지웠습니다!", Toast.LENGTH_SHORT).show()
         }
-    }
-
-    private fun showChangeDialog() {
-        val buttonArray = ArrayList<StormDialogButton>()
-        buttonArray.add(StormDialogButton("취소", true, null))
-
-        buttonArray.add(StormDialogButton("확인", true, object : StormDialogButton.OnClickListener {
-            override fun onClick() {
-                goToFragment(targetFragment, null)
-            }
-        }))
-
-        StormDialogBuilder(
-            StormDialogBuilder.THUNDER_LOGO, targetModeStr + getString(R.string.ask_canvas_mode_change))
-            .setContentText(getString(R.string.notice_canvas_mode_change))
-            .setHorizontalArray(buttonArray)
-            .build()
-            .show(fragmentManager!!, "notice")
     }
 
     protected abstract fun onTrashed()

--- a/app/src/main/java/com/stormers/storm/card/fragment/AddCardFragment.kt
+++ b/app/src/main/java/com/stormers/storm/card/fragment/AddCardFragment.kt
@@ -8,6 +8,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import com.stormers.storm.R
 import com.stormers.storm.base.BaseFragment
 import com.stormers.storm.canvas.fragment.CanvasDrawingFragment
+import com.stormers.storm.canvas.fragment.CanvasTextFragment
 import com.stormers.storm.card.adapter.CacheCardListAdapter
 import com.stormers.storm.ui.RoundProgressActivity
 import com.stormers.storm.util.MarginDecoration
@@ -50,7 +51,12 @@ class AddCardFragment : BaseFragment(R.layout.fragment_add_card) {
         }
 
         cardview_addcard_add.setOnClickListener {
-            goToFragment(CanvasDrawingFragment::class.java, null)
+            (mActivity as RoundProgressActivity).run {
+                canvasDrawingFragment = goToFragment(CanvasDrawingFragment::class.java, null)
+                canvasTextFragment = addFragment(CanvasTextFragment::class.java, null)
+
+                hideFragment(canvasTextFragment!!)
+            }
         }
     }
 

--- a/app/src/main/java/com/stormers/storm/ui/RoundProgressActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/RoundProgressActivity.kt
@@ -3,7 +3,10 @@ package com.stormers.storm.ui
 import android.content.Intent
 import android.os.Bundle
 import android.os.CountDownTimer
+import androidx.fragment.app.Fragment
 import com.stormers.storm.R
+import com.stormers.storm.canvas.fragment.CanvasDrawingFragment
+import com.stormers.storm.canvas.fragment.CanvasTextFragment
 import com.stormers.storm.card.fragment.AddCardFragment
 import com.stormers.storm.card.model.CacheCardModel
 import com.stormers.storm.round.base.BaseRoundProgressActivity
@@ -15,6 +18,10 @@ class RoundProgressActivity : BaseRoundProgressActivity() {
     val cardList = mutableListOf<CacheCardModel>()
 
     private lateinit var countDownTimer: CountDownTimer
+
+    var addCardFragment: Fragment? = null
+    var canvasDrawingFragment: Fragment? = null
+    var canvasTextFragment: Fragment? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,7 +37,7 @@ class RoundProgressActivity : BaseRoundProgressActivity() {
 
         countDown(roundTime)
 
-        goToFragment(AddCardFragment::class.java, null)
+        addCardFragment = goToFragment(AddCardFragment::class.java, null)
     }
 
     override fun initFragmentId(): Int? {


### PR DESCRIPTION
피엠님께서

글과 그림을 전환할 때 다이얼로그가 뜨지 않고 바로 전환되도록 수정 요청하셨습니다.

그리고 전환하더라도 이전 내용이 남아있도록 하여씁니다

감사합니다.