### PR TITLE
fix: 참여한 프로젝트가 0개일 때 리사이클러뷰 숨기기

### DIFF
--- a/app/src/main/java/com/stormers/storm/project/data/source/remote/ProjectsRemoteDataSource.kt
+++ b/app/src/main/java/com/stormers/storm/project/data/source/remote/ProjectsRemoteDataSource.kt
@@ -38,7 +38,12 @@ object ProjectsRemoteDataSource : ProjectsDataSource {
                 if (response.isSuccessful) {
                     if (response.body()!!.success) {
                         Log.d(TAG, "getProjectPreviews: Success")
-                        callback.onProjectsLoaded(response.body()!!.data)
+
+                        if (response.body()!!.data.isEmpty()) {
+                            callback.onDataNotAvailable()
+                        } else {
+                            callback.onProjectsLoaded(response.body()!!.data)
+                        }
                     } else {
                         Log.d(TAG, "getProjectPreviews: Not Success, ${response.body()!!.message}")
                         callback.onDataNotAvailable()


### PR DESCRIPTION
기존에는 서버한테 응답이 오기만 하면 리사이클러뷰를 보여주고 참가한 프로젝트가 없다는 뷰를 숨겼는데,

응답이 왔지만 내용물이 비어 있어도 참가한 프로젝트가 없다는 뷰를 보여주도록 수정했으 !