### PR TITLE
fix: 모든 라운딩 처리 된 프로필 이미지에 centerCrop 속성 적용

### DIFF
--- a/app/src/main/res/layout/item_expandcard_card.xml
+++ b/app/src/main/res/layout/item_expandcard_card.xml
@@ -45,6 +45,7 @@
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:background="@color/storm_red"
+                android:scaleType="centerCrop"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintDimensionRatio="1:1"
                 app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_participant_with_profile.xml
+++ b/app/src/main/res/layout/item_participant_with_profile.xml
@@ -9,6 +9,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:background="@color/storm_yellow"
+        android:scaleType="centerCrop"
         app:layout_constraintBottom_toBottomOf="@id/textview_participantitem_name"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintEnd_toStartOf="@id/textview_participantitem_name"

--- a/app/src/main/res/layout/item_user_profile.xml
+++ b/app/src/main/res/layout/item_user_profile.xml
@@ -10,6 +10,7 @@
         android:layout_width="14dp"
         android:layout_height="0dp"
         android:background="@color/storm_yellow"
+        android:scaleType="centerCrop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
간단한 pr 입니다!!
가로로 혹은 세로로 길쭉한 이미지가 라운딩 처리된 이미지뷰에 양옆 검은 여백을 남기고 들어가지 않도록 centerCrop 속성을 주었습니다!
꼼꼼히 확인했지만 혹여나...빠진 부분을 눈치채신다면 말씀해주세요!!!