### PR TITLE
feat: 카드 상세보기 버튼으로 카드 이동

### DIFF
--- a/app/src/main/java/com/stormers/storm/card/fragment/ExpandRoundCardFragment.kt
+++ b/app/src/main/java/com/stormers/storm/card/fragment/ExpandRoundCardFragment.kt
@@ -110,8 +110,19 @@ class ExpandRoundCardFragment: BaseFragment(R.layout.fragment_expand_card) {
                 Toast.makeText(context, "메모가 저장되었습니다", Toast.LENGTH_SHORT).show()
             }
         }
-    }
 
+        imagebutton_before_card.setOnClickListener {
+            cardViewPager.run {
+                currentItem -= 1
+            }
+        }
+
+        imagebutton_next_card.setOnClickListener {
+            cardViewPager.run {
+                currentItem += 1
+            }
+        }
+    }
 
     private fun initViewPager(data: List<CardWithOwnerModel>) {
         cardViewPager.run {
@@ -121,12 +132,26 @@ class ExpandRoundCardFragment: BaseFragment(R.layout.fragment_expand_card) {
             registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
                 override fun onPageSelected(position: Int) {
                     super.onPageSelected(position)
+                    setVisibilityOfMoveButton(position, data.size)
+
                     currentPage = position
                     roundCardChangeCallback?.onCardPageChanged(position, expandRoundCardAdapter.itemCount, data[position])
                     setMemo(position, data)
                 }
             })
             currentItem = currentPage
+        }
+    }
+
+    private fun setVisibilityOfMoveButton(position: Int, length: Int) {
+        imagebutton_before_card.visibility = View.VISIBLE
+        imagebutton_next_card.visibility = View.VISIBLE
+
+        if (position == 0) {
+            imagebutton_before_card.visibility = View.GONE
+        }
+        if (position == length - 1) {
+            imagebutton_next_card.visibility = View.GONE
         }
     }
 

--- a/app/src/main/java/com/stormers/storm/card/fragment/ExpandScrapedCardFragment.kt
+++ b/app/src/main/java/com/stormers/storm/card/fragment/ExpandScrapedCardFragment.kt
@@ -94,6 +94,18 @@ class ExpandScrapedCardFragment: BaseFragment(R.layout.fragment_expand_card) {
                 Toast.makeText(context, "메모가 저장되었습니다.", Toast.LENGTH_SHORT).show()
             }
         }
+
+        imagebutton_before_card.setOnClickListener {
+            cardViewPager.run {
+                currentItem -= 1
+            }
+        }
+
+        imagebutton_next_card.setOnClickListener {
+            cardViewPager.run {
+                currentItem += 1
+            }
+        }
     }
 
     private fun initViewPager(data: List<ScrapedCardWithRoundInfo>) {
@@ -104,12 +116,26 @@ class ExpandScrapedCardFragment: BaseFragment(R.layout.fragment_expand_card) {
             registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
                 override fun onPageSelected(position: Int) {
                     super.onPageSelected(position)
+                    setVisibilityOfMoveButton(position, data.size)
+
                     currentPage = position
                     scrapedCardChangeCallback?.onCardPageChanged(position, expandScrapedCardAdapter.itemCount, data[position])
                     setMemo(position, data)
                 }
             })
             currentItem = currentPage
+        }
+    }
+
+    private fun setVisibilityOfMoveButton(position: Int, length: Int) {
+        imagebutton_before_card.visibility = View.VISIBLE
+        imagebutton_next_card.visibility = View.VISIBLE
+
+        if (position == 0) {
+            imagebutton_before_card.visibility = View.GONE
+        }
+        if (position == length - 1) {
+            imagebutton_next_card.visibility = View.GONE
         }
     }
 

--- a/app/src/main/res/layout/fragment_expand_card.xml
+++ b/app/src/main/res/layout/fragment_expand_card.xml
@@ -5,37 +5,14 @@
     android:elevation="10dp"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <ImageButton
-        android:id="@+id/imagebutton_before_card"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="40dp"
-        android:background="@drawable/all_roundmeeting_before"
-        android:elevation="10dp"
-        app:layout_constraintBottom_toBottomOf="@+id/imagebutton_next_card"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/imagebutton_next_card" />
-
-    <ImageButton
-        android:id="@+id/imagebutton_next_card"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="40dp"
-        android:background="@null"
-        android:elevation="10dp"
-        android:src="@drawable/all_roundmeeting_next"
-        app:layout_constraintBottom_toBottomOf="@+id/viewpager_expandcard"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/viewpager_expandcard" />
-
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/viewpager_expandcard"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:clipChildren="false"
         android:elevation="10dp"
-        app:layout_constraintHeight_percent="0.71"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHeight_percent="0.71"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
@@ -72,6 +49,34 @@
             android:textSize="13sp" />
 
     </androidx.cardview.widget.CardView>
+
+    <ImageButton
+        android:id="@+id/imagebutton_before_card"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@null"
+        android:src="@drawable/all_roundmeeting_before"
+        android:elevation="10dp"
+        android:paddingEnd="100dp"
+        android:paddingStart="20dp"
+        android:paddingVertical="100dp"
+        app:layout_constraintBottom_toBottomOf="@+id/imagebutton_next_card"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/imagebutton_next_card" />
+
+    <ImageButton
+        android:id="@+id/imagebutton_next_card"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@null"
+        android:elevation="10dp"
+        android:src="@drawable/all_roundmeeting_next"
+        android:paddingEnd="20dp"
+        android:paddingStart="100dp"
+        android:paddingVertical="100dp"
+        app:layout_constraintBottom_toBottomOf="@+id/viewpager_expandcard"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/viewpager_expandcard" />
 
     <com.stormers.storm.customview.StormButton
         android:id="@+id/stormbutton_expandcard_apply"


### PR DESCRIPTION
피엠님이 간곡히 요청하던, 밋밋목마 양쪽 버튼으로 카드 이동하는 기능 추가했어

대충 눌러도 터치가 되도록 패딩을 어마어마하게 줘서 그냥 좌우측 누른다 싶으면 동작해 !

RoundCardList랑 ScrapCardList 랑 사용하는 모델이 달라서 똑같은 클래스인데도 따로 만들어둔 것이 너무너무너무 거슬리나..... 어쩔 수 없다...