### PR TITLE
feat: 최근 참가한 프로젝트 목록 캐싱

### DIFF
--- a/app/src/main/java/com/stormers/storm/round/base/BaseRoundWaitingActivity.kt
+++ b/app/src/main/java/com/stormers/storm/round/base/BaseRoundWaitingActivity.kt
@@ -21,6 +21,9 @@ open class BaseRoundWaitingActivity : OnProjectActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_round_setting)
 
+        //참여한 프로젝트에 해당 프로젝트가 추가되었으므로 이 사실을 기록
+        GlobalApplication.projectPreviewIsDirty = true
+
         setStormToolbar(stormtoolbar_roundsetting)
 
         //나가기 버튼 활성화

--- a/app/src/main/java/com/stormers/storm/ui/GlobalApplication.kt
+++ b/app/src/main/java/com/stormers/storm/ui/GlobalApplication.kt
@@ -82,6 +82,6 @@ class GlobalApplication : Application() {
 
         var isHost: Boolean = false
 
-
+        var projectPreviewIsDirty = false
     }
 }

--- a/app/src/main/java/com/stormers/storm/ui/MainActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/MainActivity.kt
@@ -58,6 +58,8 @@ class MainActivity : BaseActivity() {
 
         initView()
 
+        loadProjectPreviews()
+
         initListener()
 
         setUpperCase()
@@ -69,12 +71,18 @@ class MainActivity : BaseActivity() {
 
     override fun onResume() {
         super.onResume()
-        loadProjectPreviews()
 
         GlobalApplication.run {
             currentRound = null
             currentProject = null
             isHost = false
+
+            //참여한 프로젝트 목록에 변화가 있으면
+            if (projectPreviewIsDirty) {
+                //목록 갱신
+                loadProjectPreviews()
+                projectPreviewIsDirty = false
+            }
         }
     }
 
@@ -122,13 +130,9 @@ class MainActivity : BaseActivity() {
         }
 
         edittext_input_participate_code.addTextChangedListener(object : TextWatcher {
-            override fun afterTextChanged(s: Editable?) {
+            override fun afterTextChanged(s: Editable?) { }
 
-            }
-
-            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
-
-            }
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { }
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 //공백이 아니면 전체 지우기 버튼 활성화


### PR DESCRIPTION
최근 참가한 프로젝트가 매번 서버에서 데이터를 받아와 갱신하고 있었는데, 사실 프로젝트를 새로 만들거나 참가하지 않는 이상 이 데이터는 동결되기 때문에 그 때에만 갱신하도록 기존 데이터를 캐싱했어 !