### PR TITLE
refactor: 라운드 진행 중 디바이스 뒤로가기 키를 눌러도 그냥 나가지지 않도록 수정

### DIFF
--- a/app/src/main/java/com/stormers/storm/round/base/BaseRoundWaitingActivity.kt
+++ b/app/src/main/java/com/stormers/storm/round/base/BaseRoundWaitingActivity.kt
@@ -40,6 +40,10 @@ open class BaseRoundWaitingActivity : OnProjectActivity() {
         }
     }
 
+    override fun onBackPressed() {
+        showExitDialog()
+    }
+
     //나가기 다이얼로그에서 확인을 눌렀을 때
     override fun onExitDialogPositiveClick() {
         super.onExitDialogPositiveClick()

--- a/app/src/main/java/com/stormers/storm/round/base/OnProjectActivity.kt
+++ b/app/src/main/java/com/stormers/storm/round/base/OnProjectActivity.kt
@@ -100,7 +100,7 @@ abstract class OnProjectActivity: BaseActivity() {
     }
 
     //나가기 다이얼로그 띄우기
-    private fun showExitDialog() {
+    protected fun showExitDialog() {
         if (exitDialogButtons.isEmpty()) {
             exitDialogButtons.add(StormDialogButton("취소", true, null))
             exitDialogButtons.add(StormDialogButton("확인", true, object : StormDialogButton.OnClickListener {

--- a/app/src/main/java/com/stormers/storm/ui/HostRoundFinishActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/HostRoundFinishActivity.kt
@@ -81,4 +81,9 @@ class HostRoundFinishActivity : BaseRoundFinishActivity() {
             .setButtonArray(buttonArray)
             .build()
     }
+
+    override fun onBackPressed() {
+        //뒤로 버튼을 눌러도 나갈 수 없음
+        Log.d(TAG, "onBackPressed()")
+    }
 }

--- a/app/src/main/java/com/stormers/storm/ui/MemberRoundFinishActivity.kt
+++ b/app/src/main/java/com/stormers/storm/ui/MemberRoundFinishActivity.kt
@@ -5,11 +5,8 @@ import android.os.Bundle
 import android.util.Log
 import android.view.View
 import com.stormers.storm.R
-import com.stormers.storm.customview.dialog.StormDialogBuilder
-import com.stormers.storm.customview.dialog.StormDialogButton
 import com.stormers.storm.network.BaseResponse
 import com.stormers.storm.network.RetrofitClient
-import com.stormers.storm.network.SimpleResponse
 import com.stormers.storm.network.SocketClient
 import com.stormers.storm.round.base.BaseRoundFinishActivity
 import com.stormers.storm.round.model.RoundEnterModel
@@ -111,5 +108,9 @@ class MemberRoundFinishActivity : BaseRoundFinishActivity() {
                     }
                 }
             })
+    }
+
+    override fun onBackPressed() {
+        //Todo: 나가기 기능 되살리기
     }
 }


### PR DESCRIPTION
이제보니 라운드 진행 중에 디바이스 자체 뒤로가기 버튼을 바로 나가지고 메인화면으로 가길래... (몰랐으면 큰일날뻔)

툴바에 나가기 버튼을 눌렀을 때와 동일하게 동작하도록 수정했고 그래서 나가기 통신을 하면서 나갈 수 있게 되었으

라운드 회의 뷰에서는 뒤로가기 버튼을 눌러도 아무런 동작을 하지 않게 했어 ~

멤버의 경우는 나가기 통신을 해야하는데 다른 브랜치에서 할게 ~