### PR TITLE
Hotfix/change base url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ fabric.properties
 /app/google-services.json
 ### key
 keystores/
+
+# SecretStrings. ex) baseUrl
+app/src/main/java/com/stormers/storm/SecretStrings.kt

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -86,7 +86,7 @@ dependencies {
 
     //Retrofit2
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.squareup.retrofit2:retrofit:2.7.1'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.7.1'
 
     //평화랑 겹칠 수 있음 둘 중 하나 지우기

--- a/app/src/main/java/com/stormers/storm/network/RetrofitClient.kt
+++ b/app/src/main/java/com/stormers/storm/network/RetrofitClient.kt
@@ -1,12 +1,11 @@
 package com.stormers.storm.network
 
-import com.stormers.storm.ui.LoginActivity
+import com.stormers.storm.SecretStrings
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
-import retrofit2.create
 
 object RetrofitClient {
-    private const val BASE_URL = "http://3.34.179.75:3000"
+    private const val BASE_URL = SecretStrings.BASE_URL
 
     private fun getInstance() : Retrofit {
         return Retrofit.Builder()

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ buildscript {
     }
 
     project.ext {
-        versionCode = 2
-        versionName = "1.1.1"
+        versionCode = 3
+        versionName = "1.1.2"
 
         compileSdkVersion = 30
         targetSdkVersion = 30


### PR DESCRIPTION
- BaseURL 변경 : 보안을 위해 BaseURL을 SecretStrings.kt로 분리 후, gitignore에 추가함. 
- Retrofit 버전 업데이트 : 안드로이드 10을 타겟으로 하는 기기의 경우 OkHttp의 옛 버전 API를 보안 목적으로 차단하여 비정상 종료를 야기함.
- versionCode 업데이트 : 1.1.1 -> 1.1.2